### PR TITLE
setting pytorch dependency version to overcome failures.

### DIFF
--- a/RF2-linux.yml
+++ b/RF2-linux.yml
@@ -7,8 +7,11 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - pytorch
-  - pytorch-cuda=11.7
+  - pytorch=2.0.1
+  - pytorch-cuda=11.8
   - dglteam/label/cu117::dgl
   - pyg::pyg
   - bioconda::hhsuite
+  - pandas=2.2.0
+  - torchdata=0.7.1
+  - pydantic


### PR DESCRIPTION
The current main branch doesn't correctly run the example code to completion due to updates in pytorch.  It will fail after a certain point of execution with an error about expecting a graphbolt library it can't find.  I've pinned versions of some of the requirements to what was required to get everything to be functional for running against a newly downloaded and installed anaconda on both Ubuntu 22.04.X LTS and RHEL 8.  I've also added the additional requirements that caused the script to fail due to being missing.

