### PR TITLE
Update util.py to remove warning about torch.cross()

### DIFF
--- a/network/util.py
+++ b/network/util.py
@@ -107,7 +107,7 @@ def make_frame(X, Y):
     Xn = X / torch.linalg.norm(X)
     Y = Y - torch.dot(Y, Xn) * Xn
     Yn = Y / torch.linalg.norm(Y)
-    Z = torch.cross(Xn,Yn)
+    Z = torch.cross(Xn, Yn, dim=-1)
     Zn =  Z / torch.linalg.norm(Z)
 
     return torch.stack((Xn,Yn,Zn), dim=-1)


### PR DESCRIPTION
new version of pytorch requires explicit dim definition: torch.cross(,dim=-1)